### PR TITLE
Cooldown and aim focus

### DIFF
--- a/Cooldown.gd
+++ b/Cooldown.gd
@@ -1,0 +1,13 @@
+extends Label
+
+# Citation for Stopwatch
+# https://gamedevbeginner.com/how-to-make-a-timer-in-godot-count-up-down-in-minutes-seconds/#stopwatch
+# 5/5/22
+
+var time_elapsed : float = 0.0
+
+func _process(delta: float) -> void:
+	time_elapsed += delta
+	
+func start_stopwatch():
+	time_elapsed = 0

--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=61 format=2]
+[gd_scene load_steps=63 format=2]
 
 [ext_resource path="res://Player/player.png" type="Texture" id=1]
 [ext_resource path="res://Player/Player.gd" type="Script" id=2]
 [ext_resource path="res://Player/AnimationPlayer.gd" type="Script" id=3]
+[ext_resource path="res://World/Stopwatch.tscn" type="PackedScene" id=4]
+[ext_resource path="res://World/Cooldown.tscn" type="PackedScene" id=5]
 
 [sub_resource type="Animation" id=50]
 resource_name = "DrawBowDown"
@@ -636,3 +638,8 @@ parameters/MoveReverse/blend_position = Vector2( 0, 0 )
 position = Vector2( 0, 12 )
 rotation = 1.5708
 shape = SubResource( 24 )
+
+[node name="Stopwatch" parent="." instance=ExtResource( 4 )]
+
+[node name="Cooldown" parent="." instance=ExtResource( 5 )]
+margin_bottom = 14.0

--- a/Stopwatch.gd
+++ b/Stopwatch.gd
@@ -1,0 +1,19 @@
+extends Label
+
+# Citation for Stopwatch
+# https://gamedevbeginner.com/how-to-make-a-timer-in-godot-count-up-down-in-minutes-seconds/#stopwatch
+# 5/5/22
+
+var time_elapsed : float = 0.0
+var running = false
+
+func _process(delta: float) -> void:
+	if running:
+		time_elapsed += delta
+	
+func start_stopwatch():
+	time_elapsed = 0
+	running = true
+	
+func stop_stopwatch():
+	running = false

--- a/World/Cooldown.tscn
+++ b/World/Cooldown.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://Cooldown.gd" type="Script" id=1]
+
+[node name="Cooldown" type="Label"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )

--- a/World/Stopwatch.tscn
+++ b/World/Stopwatch.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://Stopwatch.gd" type="Script" id=1]
+
+[node name="Stopwatch" type="Label"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )


### PR DESCRIPTION
Removed requirement for arrows to only be fired at full draw. Instead, an arrow can be fired instantly at a cost of accuracy which can be adjusted with the "spread" variable. At full draw the arrow should be pinpoint accurate. Additionally, added a cooldown adjustable by the "attack_cooldown" variable that prevents the player from spamming inaccurate arrows.