### PR TITLE
Added soft collision to bats

### DIFF
--- a/Enemies/Bat.gd
+++ b/Enemies/Bat.gd
@@ -1,5 +1,6 @@
 extends KinematicBody2D
 
+
 var dir = Vector2()
 var player
 var offset = 20
@@ -7,11 +8,14 @@ var velocity = Vector2.ZERO
 var path: Array = []
 var levelNavigation: Navigation2D = null
 onready var room = get_tree().current_scene
+onready var softCollision = $SoftCollision
+
 
 # Bat Stats
 export var speed : int = 20
 export var drop_chance : float = 50
 export var health : int = 1
+
 
 # Preloaded .tscn
 var fireball = preload("res://Fireball/Fireball.tscn")
@@ -19,6 +23,7 @@ var Chest = preload("res://World/Chest.tscn")
 var DeathSound = preload("res://Music and Sounds/BatDeath.tscn")
 var HitSound = preload("res://Music and Sounds/HitSound.tscn")
 var HitEffect = preload("res://Wizard Pack/HitEffectSmall.tscn")
+
 
 func _ready():
 	player = constants.player
@@ -31,8 +36,10 @@ func _ready():
 #	yield(owner, "ready")
 	randomize()
 
+
 func get_dir(target):
 	return (target.position - position).normalized()
+
 
 func _on_Timer_timeout():
 	dir = get_dir(player)
@@ -51,7 +58,9 @@ func _physics_process(delta):
 		navigate()
 	move()
 
-func navigate():	# Define the next position to go to
+
+# Define the next position to go to
+func navigate():	
 	if is_instance_valid(player):
 		if path.size() > 0:
 			velocity = global_position.direction_to(path[1]) * speed
@@ -60,14 +69,18 @@ func navigate():	# Define the next position to go to
 			if global_position == path[0]:
 				path.pop_front()
 		
-func generate_path():	# It's obvious
+		
+func generate_path():
 	if !is_instance_valid(player):
 		return
 	if levelNavigation != null and player != null:
 		path = levelNavigation.get_simple_path(global_position, player.global_position, false)
 		# line2D.points = path  # for debugging
 		
+		
 func move():
+	if softCollision.is_colliding():
+		velocity += softCollision.get_push_vector()
 	velocity = move_and_slide(velocity, Vector2(0, 0))
 	
 
@@ -87,6 +100,7 @@ func _on_Hurtbox_area_entered(area):
 			chest.position = global_position
 		get_parent().add_child(DeathSound.instance())
 		queue_free()
+	
 	
 func create_hit_effect():
 	var hitEffect = HitEffect.instance()

--- a/Enemies/Bat.tscn
+++ b/Enemies/Bat.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://Enemies/Bat.png" type="Texture" id=1]
 [ext_resource path="res://Enemies/SmallShadow.png" type="Texture" id=2]
 [ext_resource path="res://Enemies/Bat.gd" type="Script" id=3]
 [ext_resource path="res://Hitbox/Hurtbox.tscn" type="PackedScene" id=4]
+[ext_resource path="res://Hitbox/SoftCollision.tscn" type="PackedScene" id=5]
 
 [sub_resource type="AtlasTexture" id=1]
 atlas = ExtResource( 1 )
@@ -56,7 +57,7 @@ health = 2
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 6 )
 animation = "Fly"
-frame = 2
+frame = 1
 playing = true
 offset = Vector2( 0, -12 )
 
@@ -64,9 +65,11 @@ offset = Vector2( 0, -12 )
 texture = ExtResource( 2 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+visible = false
 shape = SubResource( 7 )
 
 [node name="Hurtbox" parent="." instance=ExtResource( 4 )]
+visible = false
 position = Vector2( 8, 8 )
 collision_layer = 64
 collision_mask = 16
@@ -86,8 +89,11 @@ collision_layer = 32768
 collision_mask = 5
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hitbox"]
+visible = false
 position = Vector2( 0, -12 )
 shape = SubResource( 9 )
+
+[node name="SoftCollision" parent="." instance=ExtResource( 5 )]
 
 [connection signal="area_entered" from="Hurtbox" to="." method="_on_Hurtbox_area_entered"]
 

--- a/Hitbox/SoftCollision.gd
+++ b/Hitbox/SoftCollision.gd
@@ -1,0 +1,16 @@
+extends Area2D
+
+
+func is_colliding():
+	var areas = get_overlapping_areas()
+	return areas.size() > 0
+	
+	
+func get_push_vector():
+	var areas = get_overlapping_areas()
+	var push_vector = Vector2.ZERO
+	if is_colliding():
+		var area = areas[0]
+		push_vector = area.global_position.direction_to(global_position).normalized()
+		
+	return push_vector

--- a/Hitbox/SoftCollision.tscn
+++ b/Hitbox/SoftCollision.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://Hitbox/SoftCollision.gd" type="Script" id=1]
+
+[sub_resource type="CapsuleShape2D" id=1]
+radius = 3.0
+height = 0.0
+
+[node name="SoftCollision" type="Area2D"]
+collision_layer = 256
+collision_mask = 256
+script = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )

--- a/project.godot
+++ b/project.godot
@@ -109,6 +109,7 @@ enter={
 2d_physics/layer_6="PlayerHurtbox"
 2d_physics/layer_7="EnemyHurtbox"
 2d_physics/layer_8="Chest"
+2d_physics/layer_9="SoftCollision"
 
 [physics]
 


### PR DESCRIPTION
Created a new scene called Soft Collision that can be added to any character. Not advisable though to add to player as you don't want enemies pushed away probably. This layer is used to prevent entities from stacking on top of each other.